### PR TITLE
Fix moose-bird exiting early bug

### DIFF
--- a/etc/profile.sh
+++ b/etc/profile.sh
@@ -6,9 +6,9 @@ if [ -d "$FLIGHT_DIRECT_ROOT"/etc/profile.d ]; then
   for i in "$FLIGHT_DIRECT_ROOT"/etc/profile.d/*.sh ; do
     if [ -r "$i" ]; then
       if [ "${-#*i}" != "\$-" ]; then
-        . "$i"
+        (. "$i")
       else
-        . "$i" >/dev/null 2>&1
+        (. "$i" >/dev/null 2>&1)
       fi
     fi
   done

--- a/etc/profile.sh
+++ b/etc/profile.sh
@@ -1,0 +1,16 @@
+# Sets up the `FlightDirect` environment
+export FLIGHT_DIRECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+# Runs the other files in profile.d
+if [ -d "$FLIGHT_DIRECT_ROOT"/etc/profile.d ]; then
+    for i in "$FLIGHT_DIRECT_ROOT"/etc/profile.d/*.sh ; do
+        if [ -r "$i" ]; then
+            if [ "${-#*i}" != "\$-" ]; then
+                . "$i"
+            else
+                . "$i" >/dev/null 2>&1
+            fi
+        fi
+    done
+  unset i
+fi

--- a/etc/profile.sh
+++ b/etc/profile.sh
@@ -3,14 +3,14 @@ export FLIGHT_DIRECT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 # Runs the other files in profile.d
 if [ -d "$FLIGHT_DIRECT_ROOT"/etc/profile.d ]; then
-    for i in "$FLIGHT_DIRECT_ROOT"/etc/profile.d/*.sh ; do
-        if [ -r "$i" ]; then
-            if [ "${-#*i}" != "\$-" ]; then
-                . "$i"
-            else
-                . "$i" >/dev/null 2>&1
-            fi
-        fi
-    done
+  for i in "$FLIGHT_DIRECT_ROOT"/etc/profile.d/*.sh ; do
+    if [ -r "$i" ]; then
+      if [ "${-#*i}" != "\$-" ]; then
+        . "$i"
+      else
+        . "$i" >/dev/null 2>&1
+      fi
+    fi
+  done
   unset i
 fi

--- a/package-scripts/flight-direct/postinst
+++ b/package-scripts/flight-direct/postinst
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# When "flight-direct" is installed (e.g. `rpm -i`), it will run this script.
+# When "flight-direct" is installed (e.g. `yum install`), it will run this script.
 # This script has been adapted from clusterware:
 # https://raw.githubusercontent.com/alces-software/clusterware/064d7a6e7a2f8d2a3f1874415c0bd8ee429099f7/dist/profile/alces-clusterware.csh
 #
@@ -8,35 +8,6 @@
 # https://github.com/scoutapp/omnibus-scout
 #
 
-name='flight-direct'
-cmd_name='flight'
-install_dir="/opt/$name"
-profile_path="/etc/profile.d/alces-$name.sh"
-
-cat > "$profile_path" <<-PROFILE
-if [ -d $install_dir/etc/profile.d ]; then
-    for i in $install_dir/etc/profile.d/*.sh ; do
-        if [ -r "\$i" ]; then
-            if [ "\${-#*i}" != "\$-" ]; then
-                . "\$i"
-            else
-                . "\$i" >/dev/null 2>&1
-            fi
-        fi
-    done
-  unset i
-fi
-PROFILE
-
-cat <<-MSG
-
-Thank you for installing alces: $name!
-
-Please login again, or manually run the following:
-source $profile_path
-
-Afterwards, execute '$cmd_name' for further information.
-
-MSG
+echo "source /opt/flight-direct/etc/profile.sh" > /etc/profile.d/alces-flight-direct.sh
 
 exit 0


### PR DESCRIPTION
On profile load, the `moose-bird` flies at the user. This can be stopped early by hitting space. However this causes `sudo su` to fail as the command does not finish correctly.

The fix is to run all `profile.d` scripts in individual sub-shell. This prevents the moose bird `exit` to stop the whole command.

In the process, a `etc/profile.sh` script has been created. It is now responsible for running the `profile.d` files. It also inspects the `BASH_SOURCE` to determine the project root/ install directory.

Now the `PostInst` script that runs after `yum install`, will source the main `etc/profile.sh` script instead. This should make it easier to create a user friendly version in the future.