### PR TITLE
Implement the basics for a production build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "opt/clusterware"]
+	path = opt/clusterware
+	url = git@github.com:alces-software/clusterware.git

--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,4 +1,4 @@
 
 module FlightDirect
-  VERSION = '0.1.0'.freeze
+  VERSION = '0.1.1'.freeze
 end

--- a/production-vm/Vagrantfile
+++ b/production-vm/Vagrantfile
@@ -6,9 +6,41 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 
-$dev_path='/tmp/omnibus-flight-direct'
+# Requires the version of FlightDirect that is being built
+require_relative File.join(
+  File.dirname(__FILE__), '..', 'lib', 'flight_direct', 'version.rb'
+)
 
+$dev_path = '/tmp/omnibus-flight-direct'
+$build_dir= '~/production-build'
+$build_root = "#{$build_dir}/flight-direct"
+
+# NOTE: rpm-build is only installed so the omnibus build doesn't fail, and
+# exits normally. The `rpm` is otherwise ignored
 $script = <<-SCRIPT
+  # Exit if anything exists with a non-zero status
+  set -e
+
+  # Installs the required yum packages
+  yum install git rpm-build -y
+
+  # Installs a stable version of ruby with rvm
+  gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+  curl -sSL https://get.rvm.io | bash -s stable --ruby
+  source /usr/local/rvm/scripts/rvm
+
+  # Installs the development gems
+  cd #{$dev_path}
+  gem install bundler
+  bundle install --without default --with development
+
+  # Builds the project
+  export FLIGHT_DIRECT_ROOT=#{$build_root}
+  omnibus build flight-direct
+
+  # Creates the tarball
+  cd #{$build_dir}
+  tar -zcvf flight-direct-#{FlightDirect::VERSION}.tar.gz flight-direct
 SCRIPT
 
 Vagrant.configure(2) do |config|

--- a/production-vm/Vagrantfile
+++ b/production-vm/Vagrantfile
@@ -1,0 +1,22 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+
+$dev_path='/tmp/omnibus-flight-direct'
+
+$script = <<-SCRIPT
+SCRIPT
+
+Vagrant.configure(2) do |config|
+  config.vm.box = 'centos/7'
+  config.vm.network "private_network", type: 'dhcp'
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+
+  config.vm.synced_folder '..', $dev_path
+  config.vm.provision 'shell', inline: $script
+  config.vm.provider('virtualbox') { |v| v.cpus = `nproc`.to_i }
+end


### PR DESCRIPTION
A new `Vagrantfile` has been added to build production tarballs of `flight`. There has been a few issues with the `clusterware` subrepo not being cloned and thus a `.gitmodule` file has been added.

This module file is required to clone clusterware correct and thus build flight direct. Therefore the minor version number has been bumped to allow this PR to be built