### PR TITLE
Use the https protocol for the subrepo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "opt/clusterware"]
 	path = opt/clusterware
-	url = git@github.com:alces-software/clusterware.git
+	url = https://github.com/alces-software/clusterware


### PR DESCRIPTION
This means other machines that clone `flight-direct` do not require a
`ssh` key to clone the repo. Instead they will use the `https` protocol