### PR TITLE
Bump the minor version number

### DIFF
--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,4 +1,4 @@
 
 module FlightDirect
-  VERSION = '0.1.1'.freeze
+  VERSION = '0.1.2'.freeze
 end


### PR DESCRIPTION
This allows another build to occur with the update `https` protocol for the clusterware subrepo.