### PR TITLE
Fix the S3 publishing and ensure the correct build code is used

### DIFF
--- a/production-vm/Vagrantfile
+++ b/production-vm/Vagrantfile
@@ -48,7 +48,7 @@ $script = <<-SCRIPT
   # Publishes the tarball to S3
   export PATH=~/.local/bin:$PATH
   pip install awscli --upgrade --user
-  aws s3 #{$tarball_name} s3://flight-direct/releases/el7
+  aws s3 cp #{$tarball_name} s3://flight-direct/releases/el7
 SCRIPT
 
 Vagrant.configure(2) do |config|

--- a/production-vm/Vagrantfile
+++ b/production-vm/Vagrantfile
@@ -14,6 +14,7 @@ require_relative File.join(
 $dev_path = '/tmp/omnibus-flight-direct'
 $build_dir= '~/production-build'
 $build_root = "#{$build_dir}/flight-direct"
+$tarball_name = "flight-direct-#{FlightDirect::VERSION}.tar.gz"
 
 # NOTE: rpm-build is only installed so the omnibus build doesn't fail, and
 # exits normally. The `rpm` is otherwise ignored
@@ -22,7 +23,9 @@ $script = <<-SCRIPT
   set -e
 
   # Installs the required yum packages
-  yum install git rpm-build -y
+  yum install epel-release -y
+  yum update -y
+  yum install git rpm-build python-pip -y
 
   # Installs a stable version of ruby with rvm
   gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
@@ -40,7 +43,11 @@ $script = <<-SCRIPT
 
   # Creates the tarball
   cd #{$build_dir}
-  tar -zcvf flight-direct-#{FlightDirect::VERSION}.tar.gz flight-direct
+  tar -zcvf #{$tarball_name} flight-direct
+
+  # Publishes the tarball to S3
+  pip install awscli --upgrade --user
+  aws s3 #{$tarball_name} s3://flight-direct/releases
 SCRIPT
 
 Vagrant.configure(2) do |config|
@@ -49,6 +56,11 @@ Vagrant.configure(2) do |config|
   config.vm.synced_folder ".", "/vagrant", disabled: true
 
   config.vm.synced_folder '..', $dev_path
-  config.vm.provision 'shell', inline: $script
+
+  # Runs the deployment script
+  env_vars = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY']
+  config.vm.provision 'shell',
+    inline: $script,
+    env: env_vars.map { |v| [v, ENV[v]] }.to_h
   config.vm.provider('virtualbox') { |v| v.cpus = `nproc`.to_i }
 end

--- a/production-vm/Vagrantfile
+++ b/production-vm/Vagrantfile
@@ -6,6 +6,8 @@
 # backwards compatibility). Please don't change it unless you know what
 # you're doing.
 
+require 'erb'
+
 # Requires the version of FlightDirect that is being built
 require_relative File.join(
   File.dirname(__FILE__), '..', 'lib', 'flight_direct', 'version.rb'
@@ -21,6 +23,21 @@ $tarball_name = "flight-direct-#{FlightDirect::VERSION}.tar.gz"
 $script = <<-SCRIPT
   # Exit if anything exists with a non-zero status
   set -e
+
+  # Ensures the build environment is clean and is working off
+  # the correct git tag
+  <%  unless `git status --porcelain`.empty? %>
+    echo 'There is uncommited work in the git repo' >&2
+    exit 1
+  <%  end %>
+  <%
+      head_sum = `git rev-list -n 1 HEAD`
+      tag_sum = `git rev-list -n 1 #{FlightDirect::VERSION}`
+      unless head_sum == tag_sum
+  %>
+    echo 'You must build off the tagged commit' 2>&2
+    exit 1
+  <%  end %>
 
   # Installs the required yum packages
   yum install epel-release -y
@@ -61,7 +78,7 @@ Vagrant.configure(2) do |config|
   # Runs the deployment script
   env_vars = ['AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY']
   config.vm.provision 'shell',
-    inline: $script,
+    inline: ERB.new($script).result(binding),
     env: env_vars.map { |v| [v, ENV[v]] }.to_h
   config.vm.provider('virtualbox') { |v| v.cpus = `nproc`.to_i }
 end

--- a/production-vm/Vagrantfile
+++ b/production-vm/Vagrantfile
@@ -46,8 +46,9 @@ $script = <<-SCRIPT
   tar -zcvf #{$tarball_name} flight-direct
 
   # Publishes the tarball to S3
+  export PATH=~/.local/bin:$PATH
   pip install awscli --upgrade --user
-  aws s3 #{$tarball_name} s3://flight-direct/releases
+  aws s3 #{$tarball_name} s3://flight-direct/releases/el7
 SCRIPT
 
 Vagrant.configure(2) do |config|

--- a/production-vm/Vagrantfile
+++ b/production-vm/Vagrantfile
@@ -48,7 +48,7 @@ $script = <<-SCRIPT
   # Publishes the tarball to S3
   export PATH=~/.local/bin:$PATH
   pip install awscli --upgrade --user
-  aws s3 cp #{$tarball_name} s3://flight-direct/releases/el7
+  aws s3 cp #{$tarball_name} s3://flight-direct/releases/el7/#{$tarball_name}
 SCRIPT
 
 Vagrant.configure(2) do |config|


### PR DESCRIPTION
The major change from version `0.1.3` is the automatic publishing to `S3`. After the tarball has been built, the `aws-cli` is `pip` installed and publishes to an S3 repo. The `aws` credentials are read from the host machines environment.

However this does create a problem between "source code" and "build code" versioning. Essentially, version `0.1.3` used the build code for what will become the `0.1.4` release. This isn't a good idea due to the coupling between the two code basis.

So instead, the provisioning step checks if:
1. The checkout build code matches the tagged commit,
1. That the working directory is clean

This uses ERB to render the provisioning script, see for details: https://github.com/alces-software/flight-direct/commit/e09e1e25421fbff1c28a30bd88247590315fbfc8