### PR TITLE
Tweak the bootstrap script to be more user freindly

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -2,13 +2,32 @@
 # Ensures a version is given
 set -e
 version="$1"
-: ${version?'No version number given'}
-file="flight-direct-$version.tar.gz"
+: ${version:?'No version number given'}
+tarball="flight-direct-$version.tar.gz"
+
+# Changes to the install directory
+FLIGHT_DIRECT_INSTALL_DIR=${FLIGHT_DIRECT_INSTALL_DIR:-'/opt'}
+pushd $FLIGHT_DIRECT_INSTALL_DIR >/dev/null
 
 # Fetches the tarball
-url="https://s3-eu-west-1.amazonaws.com/flight-direct/releases/el7/$file"
-curl $url > $file
+url="https://s3-eu-west-1.amazonaws.com/flight-direct/releases/el7/$tarball"
+curl -f $url > $tarball
 
 # Extracts the tarball
-tar -zxf $file
+tar -zxf $tarball
 
+# Sets up the profile
+sys_profile='/etc/profile.d/flight-direct.sh'
+fd_profile="$FLIGHT_DIRECT_INSTALL_DIR/flight-direct/etc/profile.sh"
+echo "source $fd_profile" > $sys_profile
+
+# Install Complete
+cat <<EOF
+
+FlightDirect has been successfully installed
+Restart your current shell before continuing
+
+EOF
+
+# Moves back to the original dir
+popd >/dev/null


### PR DESCRIPTION
This updated script needs to be on master so it can be referenced in quip

1. The bootstrap script will now error if it can not find the tarball
(error 404) instead of trying to untar it and error.

2. It will also automatically install to `/opt/flight-direct` which can
be changed by setting `FLIGHT_DIRECT_INSTALL_DIR`.

3. It automatically sets up the system `profile.d` to source the internal
`etc/profile.sh`.