### PR TITLE
Implement the --trace suppression in Loki

### DIFF
--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,4 +1,4 @@
 
 module FlightDirect
-  VERSION = '0.3.2'.freeze
+  VERSION = '0.3.3'.freeze
 end

--- a/lib/loki/thor_ext.rb
+++ b/lib/loki/thor_ext.rb
@@ -70,7 +70,11 @@ module Loki
 
       # Loki commands allow for additional error handling then vanilla Thor
       def define_loki_command(method)
-        define_method(method) { |*args| run_loki_command(method, *args) }
+        method_option :trace, type: :boolean,
+                      desc: 'Display the backtrace if there is an error'
+        define_method(method) do |*args|
+          run_loki_command(method, *args)
+        end
       end
     end
 
@@ -90,6 +94,9 @@ module Loki
       # TODO: Make the safer and probably test it
       e.backtrace.shift
       raise e
+    rescue => e
+      # Reraise the error if the backtrace is on
+      raise e if options.trace
     end
   end
 end

--- a/lib/loki/thor_ext.rb
+++ b/lib/loki/thor_ext.rb
@@ -39,6 +39,20 @@ module Loki
         end
       end
 
+      # Define a command with the additional error handling provided by loki
+      # The provided block creates a special run method that is then wrapped
+      # in the error handling. This way the class private methods are still
+      # accessible
+      def loki_command(method, &block)
+        # Creates the special run method from the provided block
+        no_commands do
+          define_method(run_loki_method(method), &block)
+          private run_loki_method(method)
+        end
+        # Creates the CLI command that calls the run method
+        define_loki_command(method)
+      end
+
       #
       # Equivalent of going def cmd.name .....
       # However it also describes the method first for Thor
@@ -46,6 +60,28 @@ module Loki
       def desc_method(cmd, &block)
         desc cmd.name, cmd.synopsis
         define_method(cmd.name, &block)
+      end
+
+      def run_loki_method(name)
+        :"_run_loki_#{name}"
+      end
+
+      private
+
+      # Loki commands allow for additional error handling then vanilla Thor
+      def define_loki_command(method)
+        define_method(method) do |*args|
+          begin
+            send(self.class.run_loki_method(method), *args)
+
+          # Hide the `_run_loki` method from the inbuilt Thor error handlers
+          # Thor checks the backtrace to see where the error occurs
+          # TODO: Make the safer and probably test it
+          rescue NoMethodError, ArgumentError => e
+            e.backtrace.shift
+            raise e
+          end
+        end
       end
     end
 

--- a/lib/loki/thor_ext.rb
+++ b/lib/loki/thor_ext.rb
@@ -97,6 +97,7 @@ module Loki
     rescue => e
       # Reraise the error if the backtrace is on
       raise e if options.trace
+      $stderr.puts "ERROR: #{e.message}\nUse --trace to show the backtrace"
     end
   end
 end

--- a/lib/loki/thor_ext.rb
+++ b/lib/loki/thor_ext.rb
@@ -70,18 +70,7 @@ module Loki
 
       # Loki commands allow for additional error handling then vanilla Thor
       def define_loki_command(method)
-        define_method(method) do |*args|
-          begin
-            send(self.class.run_loki_method(method), *args)
-
-          # Hide the `_run_loki` method from the inbuilt Thor error handlers
-          # Thor checks the backtrace to see where the error occurs
-          # TODO: Make the safer and probably test it
-          rescue NoMethodError, ArgumentError => e
-            e.backtrace.shift
-            raise e
-          end
-        end
+        define_method(method) { |*args| run_loki_command(method, *args) }
       end
     end
 
@@ -89,6 +78,18 @@ module Loki
       thor = Loki::Parser.file(cmd.path)
       self.class.subcommand(cmd.name, thor)
       thor.start(args)
+    end
+
+    private
+
+    def run_loki_command(method, *args)
+        send(self.class.run_loki_method(method), *args)
+    rescue NoMethodError, ArgumentError => e
+      # Hide the `_run_loki` method from the inbuilt Thor error handlers
+      # Thor checks the backtrace to see where the error occurs
+      # TODO: Make the safer and probably test it
+      e.backtrace.shift
+      raise e
     end
   end
 end

--- a/lib/loki/thor_ext.rb
+++ b/lib/loki/thor_ext.rb
@@ -72,9 +72,7 @@ module Loki
       def define_loki_command(method)
         method_option :trace, type: :boolean,
                       desc: 'Display the backtrace if there is an error'
-        define_method(method) do |*args|
-          run_loki_command(method, *args)
-        end
+        define_method(method) { |*args| run_loki_command(method, *args) }
       end
     end
 

--- a/libexec/thor/config.rb
+++ b/libexec/thor/config.rb
@@ -32,7 +32,7 @@ require 'json'
 require 'erb'
 CONFIG_PATH = File.join(FlightDirect.root_dir, 'var/flight.conf')
 
-desc 'set key1=value1 k2=v2 ...', 'Set Flight Direct config values'
+desc 'set KEY1=VALUE1 K2=V2 ...', 'Set Flight Direct config values'
 loki_command(:set) do |*jo_inputs|
   cli_hash = parse_jo_input(*jo_inputs)
   new_configs = hash_to_config_envs(cli_hash)
@@ -44,7 +44,7 @@ end
 # Configs should always be retrieved from the environment. This makes
 # them more flexible should things change in the future. The 'get'
 # command is only a user friendly wrapper
-desc 'get key', 'Retrieve a Flight Direct config value'
+desc 'get KEY', 'Retrieve a Flight Direct config value'
 loki_command(:get) do |key|
   puts FlightConfig.get(key)
 end

--- a/libexec/thor/config.rb
+++ b/libexec/thor/config.rb
@@ -33,7 +33,7 @@ require 'erb'
 CONFIG_PATH = File.join(FlightDirect.root_dir, 'var/flight.conf')
 
 desc 'set key1=value1 k2=v2 ...', 'Set Flight Direct config values'
-def set(*jo_inputs)
+loki_command(:set) do |*jo_inputs|
   cli_hash = parse_jo_input(*jo_inputs)
   new_configs = hash_to_config_envs(cli_hash)
   merged_configs = existing_configs.merge(new_configs)
@@ -45,12 +45,12 @@ end
 # them more flexible should things change in the future. The 'get'
 # command is only a user friendly wrapper
 desc 'get key', 'Retrieve a Flight Direct config value'
-def get(key)
+loki_command(:get) do |key|
   puts FlightConfig.get(key)
 end
 
 desc 'list', 'Lists all the configs loaded into the environment'
-def list
+loki_command(:list) do
   ENV.select { |k, _v| /\A#{FlightConfig::PREFIX}/.match?(k) }
      .each { |k, v| puts "#{k}=#{v}" }
 end


### PR DESCRIPTION
Loki has been updated to not display the back trace on an error. Instead it will give the short message instead. The user will be notified that `--trace` can be used to display the full back trace.

When a command is defined, a public command method and private runner method are defined. The private runner method contains the actual command code. It is called from the public command method that provides the additional `Loki` features (aka `--trace`).