### PR TITLE
Update the bootstrap script to allow for offline installs

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -26,9 +26,15 @@ curl -f $url > $tarball
 
 # Extracts the tarball
 tar -zxf $tarball
+rm $tarball
 
 # Runs the installer
 bash "$FL_INSTALL_DIR"/flight-direct/scripts/install.sh
+
+# Sets the cache-url if installed from the anvil server
+if [ "$anvil_url" ]; then
+  echo "FL_CONFIG_CACHE_URL=$anvil_url" >> flight-direct/var/flight.conf
+fi
 
 # Moves back to the original dir
 popd >/dev/null

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
-# Ensures a version is given
 set -e
-version="$1"
-: ${version:?'No version number given'}
-tarball="flight-direct-$version.tar.gz"
 
-# Sets the url
-url="https://s3-eu-west-1.amazonaws.com/flight-direct/releases/el7/$tarball"
+# The comment below is REQUIRED for bootstrapping an offline install
+# anvil_url=
+
+# Sets the tarball name and url depending on the type of install
+if [ "$anvil_url" ]; then
+  tarball='flight-direct.tar.gz'
+  url="$anvil_url/flight-direct/$tarball"
+else
+  # Ensures a version is given
+  version="$1"
+  : ${version:?'No version number given'}
+
+  tarball="flight-direct-$version.tar.gz"
+  url="https://s3-eu-west-1.amazonaws.com/flight-direct/releases/el7/$tarball"
+fi
 
 # Changes to the install directory
 FL_INSTALL_DIR=${FL_INSTALL_DIR:-'/opt'}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -26,7 +26,7 @@ curl -f $url > $tarball
 
 # Extracts the tarball
 tar -zxf $tarball
-rm $tarball
+rm -f $tarball
 
 # Runs the installer
 bash "$FL_INSTALL_DIR"/flight-direct/scripts/install.sh

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -5,12 +5,14 @@ version="$1"
 : ${version:?'No version number given'}
 tarball="flight-direct-$version.tar.gz"
 
+# Sets the url
+url="https://s3-eu-west-1.amazonaws.com/flight-direct/releases/el7/$tarball"
+
 # Changes to the install directory
 FL_INSTALL_DIR=${FL_INSTALL_DIR:-'/opt'}
 pushd $FL_INSTALL_DIR >/dev/null
 
-# Fetches the tarball
-url="https://s3-eu-west-1.amazonaws.com/flight-direct/releases/el7/$tarball"
+# Downloads the tarball
 curl -f $url > $tarball
 
 # Extracts the tarball


### PR DESCRIPTION
A new `anvil_url` variable can be set in the bootstrap script. When set, it will switch the script to install from the anvil cache instead of S3. As such, the version is not required for this type of install.

When installing from anvil, the `FL_CONFIG_CACHE_URL` will be automatically set at the end of the bootstrap. This will make configuring the nodes easier.

As this only updates the bootstrap script, a new release of `FlightDirect` is not required. The updated script only needs to be on the master branch to be active