### PR TITLE
Add the terminal prompt back into FlightDirect

### DIFF
--- a/etc/profile.d/01-banner.sh
+++ b/etc/profile.d/01-banner.sh
@@ -3,6 +3,8 @@
 # current shell. Instead it is ran in a sub-shell which prevents its failure from affecting
 # the rest of the setup
 
+# TODO: The code below is duplicated in 02-prompt.sh. Consider refactor
+
 # This script is ran by the `csh` banner script. Thus the base profile script
 # might need to be sourced
 if [ -z "$BASH_FUNC_flight" ]; then

--- a/etc/profile.d/02-prompt.sh
+++ b/etc/profile.d/02-prompt.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# TODO: The code below is duplicated in 01-banner.sh. Consider refactor
+
+# This allows profile scripts to poll for config values
+# without booting up ruby. This about 50x faster than running
+# `flight config get`
+# NOTE: THIS IS A DUMB TOOL! The input must be in capitals
+_fl_helper_config_get() {
+  echo $(
+    key="FL_CONFIG_$1"
+    set -a +e
+    source "$FL_ROOT"/var/flight.conf 2>/dev/null
+    echo "${!key}"
+  )
+}
+
+if [ "$PS1" ]; then
+  name=$(_fl_helper_config_get CLUSTERNAME)
+  role=$(_fl_helper_config_get ROLE)
+
+  if [ "$name" ]; then
+    if [ "$role" == 'master' ]; then
+      PS1="[\u@\h\[\e[38;5;68m\]($name)\[\e[0m\] \W]\\$ "
+    else
+      PS1="[\u@\h\[\e[48;5;17;38;5;33m\]($name)\[\e[0m\] \W]\\$ "
+    fi
+  else
+    PS1="[\u@\h\[\e[1;31m\](unconfigured)\[\e[0m\] \W]\\$ "
+  fi
+  unset name role
+fi
+
+unset -f _fl_helper_config_get

--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,4 +1,4 @@
 
 module FlightDirect
-  VERSION = '0.3.5'.freeze
+  VERSION = '0.3.6'.freeze
 end


### PR DESCRIPTION
This prompt was setup by the original clusterware banner script https://raw.githubusercontent.com/alces-software/clusterware/9369387d771ef20503fa3aca44de093812928577/etc/profile.d/10-banner.sh. 

Due to the changers to how `flight` sets its config values, this old script is no longer particularly useful. Also a banner script has already been create for `flight`. Instead a new `02-profile.sh` script has been add to modify the prompt.

It uses the same logic structures as the original script (in principle) EXCEPT it look for `FL_CONFIG` env vars instead of the original clusterware configs.