### PR TITLE
Revert "Fix the file permissions for the cron file"

### DIFF
--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,4 +1,4 @@
 
 module FlightDirect
-  VERSION = '0.3.7'.freeze
+  VERSION = '0.3.9'.freeze
 end

--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,4 +1,4 @@
 
 module FlightDirect
-  VERSION = '0.3.8'.freeze
+  VERSION = '0.3.7'.freeze
 end

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,7 +52,7 @@ template = File.read(template_file)
   cron_path = "/etc/cron.#{cron_time}"
   cron_file = File.join(cron_path, 'flight-direct')
   File.write(cron_file, rendered)
-  FileUtils.chmod 0644, cron_file
+  FileUtils.chmod 0755, cron_file
   FileUtils.mkdir_p File.join(ENV['FL_ROOT'], cron_path)
 end
 RUBY_SCRIPT


### PR DESCRIPTION
Reverts alces-software/flight-direct#28

This was an error, the original file permission of `0755` was correct. The `/etc/cron.d/*` files need to have permissions `0644`. However the `/etc/cron.{hourly,daily, weekly,monthly}/*` files need to be executable.