### PR TITLE
Make `flight bash/ruby` hidden commands for the user

### DIFF
--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,4 +1,4 @@
 
 module FlightDirect
-  VERSION = '0.3.7'.freeze
+  VERSION = '0.3.9'.freeze
 end

--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,4 +1,4 @@
 
 module FlightDirect
-  VERSION = '0.3.9'.freeze
+  VERSION = '0.3.10'.freeze
 end

--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,4 +1,4 @@
 
 module FlightDirect
-  VERSION = '0.3.8'.freeze
+  VERSION = '0.3.7'.freeze
 end

--- a/lib/loki/thor_ext.rb
+++ b/lib/loki/thor_ext.rb
@@ -101,6 +101,7 @@ module Loki
       # Reraise the error if the backtrace is on
       raise e if options.trace
       $stderr.puts "ERROR: #{e.message}\nUse --trace to show the backtrace"
+      exit 1
     end
   end
 end

--- a/lib/loki/thor_ext.rb
+++ b/lib/loki/thor_ext.rb
@@ -59,7 +59,11 @@ module Loki
       # However it also describes the method first for Thor
       #
       def desc_method(cmd, &block)
-        desc cmd.name, cmd.synopsis
+        # This logic hides commands from the user, but still allows them
+        # to be ran. This is particularly useful for `bash` and `ruby`
+        # methods which are used by some scripts
+        hidden = (Process.euid != 0 && cmd.hide == 'user')
+        desc cmd.name, cmd.synopsis, hide: hidden
         define_method(cmd.name, &block)
       end
 

--- a/libexec/actions/bash
+++ b/libexec/actions/bash
@@ -2,7 +2,7 @@
 : NAME: bash
 : SYNOPSIS: Open a bash shell within the flight direct environment
 : VERSION: 1.0.0
-: ROOT: true
+: HIDE: user
 : '
 #==============================================================================
 # Copyright (C) 2018 Stephen F. Norledge and Alces Software Ltd.

--- a/libexec/actions/ruby
+++ b/libexec/actions/ruby
@@ -2,7 +2,7 @@
 : NAME: ruby
 : SYNOPSIS: Runs the ruby command in the flight environment
 : VERSION: 0.0.0
-: ROOT: true
+: HIDE: user
 : '
 #==============================================================================
 # Copyright (C) 2018 Stephen F. Norledge and Alces Software Ltd.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -52,7 +52,7 @@ template = File.read(template_file)
   cron_path = "/etc/cron.#{cron_time}"
   cron_file = File.join(cron_path, 'flight-direct')
   File.write(cron_file, rendered)
-  FileUtils.chmod 0644, cron_file
+  FileUtils.chmod 0755, cron_file
   FileUtils.mkdir_p File.join(ENV['FL_ROOT'], cron_path)
 end
 RUBY_SCRIPT


### PR DESCRIPTION
The users profile scripts require the `bash` and `ruby` commands and thus they need to be in the CLI. So instead of skipping them, they are added as hidden commands.

Also, if a command errors and the traceback is suppressed, it will exit with 1.

Finally the commits that reverted version 0.3.8 have been moved into develop.