### PR TITLE
Create the `2.0.0` release of flight_direct

### DIFF
--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,4 +1,4 @@
 
 module FlightDirect
-  VERSION = '0.3.11'.freeze
+  VERSION = '2.0.0'.freeze
 end


### PR DESCRIPTION
The `0.3.11` release is the final development launch. It will become the
first version `2.0.0` release.