### PR TITLE
Update to version `0.2.0` of forge

### DIFF
--- a/config/software/forge.rb
+++ b/config/software/forge.rb
@@ -12,7 +12,7 @@
 #
 
 name "forge"
-default_version '0.1.4'
+default_version '0.2.0'
 
 source git: 'https://github.com/alces-software/forge-cli'
 

--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,4 +1,4 @@
 
 module FlightDirect
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.1'.freeze
 end


### PR DESCRIPTION
The version `2.0.1` of flight_direct uses the updated version of `forge-cli`