### PR TITLE
Release the fixed version of forge-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [2.0.1] - 2018-10-01
+### Fixed
+- Update the `forge-cli` so it can find the upstream anvil server by default

--- a/config/software/forge.rb
+++ b/config/software/forge.rb
@@ -12,7 +12,7 @@
 #
 
 name "forge"
-default_version '0.1.4'
+default_version '0.2.0'
 
 source git: 'https://github.com/alces-software/forge-cli'
 

--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,4 +1,4 @@
 
 module FlightDirect
-  VERSION = '0.3.11'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,4 +1,4 @@
 
 module FlightDirect
-  VERSION = '2.0.0'.freeze
+  VERSION = '2.0.1'.freeze
 end


### PR DESCRIPTION
The `2.0.1` release contains the fixed version of the `forge-cli`. It now contains the correct path to the default anvil server and should work out of the box.