### PR TITLE
Update the versioning to be date-based

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2018.2 (2.0.2)] - 2018-10-08
+### Changed
+- Add a date based user version number
+
 ## [2.0.1] - 2018-10-01
 ### Fixed
 - Update the `forge-cli` so it can find the upstream anvil server by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 - The version number has been removed from the short banner displayed on
-  compute nodes 
+  compute nodes
 
 ## [2.0.1] - 2018-10-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Add a date based user version number
 
+### Removed
+- The version number has been removed from the short banner displayed on
+  compute nodes 
+
 ## [2.0.1] - 2018-10-01
 ### Fixed
 - Update the `forge-cli` so it can find the upstream anvil server by default

--- a/etc/profile.d/01-banner.sh
+++ b/etc/profile.d/01-banner.sh
@@ -32,7 +32,7 @@ WARN
 }
 
 _fl_run_moosebird() {
-  local version="Flight Direct $(flight version)"
+  local version="Flight Direct $(flight version --user)"
   local dist=$(. /etc/os-release; echo $PRETTY_NAME)
   local name=$(_fl_helper_config_get CLUSTERNAME)
   name=${name:-Unconfigured}
@@ -71,7 +71,7 @@ if [[ -t 0 ]]; then
     _fl_long_banner
   else
     cat <<EOF
-[38;5;68m[40m -[ [1;38;5;249malces [1;38;5;15mflight $(flight version)[38;5;68m ]- [0m
+[38;5;68m[40m -[ [1;38;5;249malces [1;38;5;15mflight [38;5;68m ]- [0m
 EOF
   fi
 fi

--- a/etc/profile.d/01-banner.sh
+++ b/etc/profile.d/01-banner.sh
@@ -71,7 +71,7 @@ if [[ -t 0 ]]; then
     _fl_long_banner
   else
     cat <<EOF
-[38;5;68m[40m -[ [1;38;5;249malces [1;38;5;15mflight [38;5;68m ]- [0m
+[38;5;68m[40m -[ [1;38;5;249malces [1;38;5;15mflight [38;5;68m]- [0m
 EOF
   fi
 fi

--- a/lib/flight_direct/cli.rb
+++ b/lib/flight_direct/cli.rb
@@ -42,7 +42,7 @@ module FlightDirect
     end
 
     desc :version, 'Gives the Flight Direct version'
-    option :user, 'Return the user version only'
+    option :user, desc: 'Return the user version only'
     def version
       flag = options[:user] ? '' : " (#{FlightDirect::VERSION})"
       puts "#{FlightDirect::USER_VERSION}#{flag}"

--- a/lib/flight_direct/cli.rb
+++ b/lib/flight_direct/cli.rb
@@ -43,7 +43,7 @@ module FlightDirect
 
     desc :version, 'Gives the Flight Direct version'
     def version
-      puts FlightDirect::VERSION
+      puts "#{FlightDirect::USER_VERSION} (#{FlightDirect::VERSION})"
     end
 
     private

--- a/lib/flight_direct/cli.rb
+++ b/lib/flight_direct/cli.rb
@@ -42,8 +42,10 @@ module FlightDirect
     end
 
     desc :version, 'Gives the Flight Direct version'
+    option :user, 'Return the user version only'
     def version
-      puts "#{FlightDirect::USER_VERSION} (#{FlightDirect::VERSION})"
+      flag = options[:user] ? '' : " (#{FlightDirect::VERSION})"
+      puts "#{FlightDirect::USER_VERSION}#{flag}"
     end
 
     private

--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,5 +1,5 @@
 
 module FlightDirect
   VERSION = '2.0.2'.freeze
-  USER_VERSION = '2018.2'
+  USER_VERSION = '2018.2'.freeze
 end

--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,4 +1,5 @@
 
 module FlightDirect
-  VERSION = '2.0.1'.freeze
+  VERSION = '2.0.2'.freeze
+  USER_VERSION = '2018.2'
 end


### PR DESCRIPTION
The user facing version number will be date based off the year. This is what should be displayed in the long `banner`. The version has been removed completely from the short banner.

The older `semvar` based version is still used as the release tag and to label the tarballs. This means the installer bootstrap script will still fetch the binary based on the `semvar` tag.