### PR TITLE
Update forge to allow for configuration scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2018.3 (2.1.0)] - 2018-10-08
+### Added
+- Allow for optional configuration script before installing forge packages.
+
 ## [2018.2 (2.0.2)] - 2018-10-08
 ### Changed
 - Add a date based user version number

--- a/config/software/forge.rb
+++ b/config/software/forge.rb
@@ -12,7 +12,7 @@
 #
 
 name "forge"
-default_version '0.2.0'
+default_version '1.0.0'
 
 source git: 'https://github.com/alces-software/forge-cli'
 

--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,5 +1,5 @@
 
 module FlightDirect
-  VERSION = '2.0.2'.freeze
-  USER_VERSION = '2018.2'.freeze
+  VERSION = '2.1.0'.freeze
+  USER_VERSION = '2018.3'.freeze
 end


### PR DESCRIPTION
The `2.1.0` release of `flight-direct` now allows for configurable
forge installs