### PR TITLE
Remove the runtime dependency on Bundler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2018.4.pre (2.1.1)] - 2018-10-17
+### Fixed
+- Remove the runtime dependency on Bundler. This allows loki forge-packages
+  to use a separate Gemfile
+
 ## [2018.3 (2.1.0)] - 2018-10-08
 ### Added
 - Allow for optional configuration script before installing forge packages.

--- a/config/software/flight-direct.rb
+++ b/config/software/flight-direct.rb
@@ -82,11 +82,18 @@ build do
       mode: 0444,
       vars: { cw_DIST: cw_DIST }
 
-  # Installs the gems to the shared `vendor/gems/--some-where-?--`
+  # Installs the gems to the shared `vendor/share`
   flags = [
-    "--with#{overrides[:development] ? '' : 'out'} development"
+    "--with#{overrides[:development] ? '' : 'out'} development",
+    '--standalone',
+    '--path vendor/share'
   ].join(' ')
   command "cd #{install_dir} && embedded/bin/bundle install #{flags}", env: env
+
+  # Renames the bundler setup file
+  prefix = File.join(install_dir, 'vendor/share/bundler')
+  move File.expand_path('setup.rb', prefix),
+       File.expand_path('flight-direct-setup.rb', prefix)
 
   # Set the development environment variable
   if overrides[:development]

--- a/dev_bin/loki
+++ b/dev_bin/loki
@@ -16,7 +16,5 @@ args = raw_args.drop(1)
 lib_dir = file.sub(/libexec\/thor\/.*\Z/, '/lib')
 $LOAD_PATH.unshift(lib_dir) if File.directory?(lib_dir)
 
-Bundler.with_clean_env do
-  Loki::Parser.file(file).start(args)
-end
+Loki::Parser.file(file).start(args)
 

--- a/lib/flight_direct.rb
+++ b/lib/flight_direct.rb
@@ -7,9 +7,12 @@ load_root = (dev_mode && dev_root) ? dev_root : default_root
 # Sets up the load paths
 $LOAD_PATH << File.join(load_root, 'lib')
 
-# Sets up Bundler
-ENV['BUNDLE_GEMFILE'] ||= "#{load_root}/Gemfile"
-require 'bundler/setup'
+# Bundler is explicitly NOT used to at runtime. Instead a --standalone
+# setup file is generated at build time. This allows Bundler to be used
+# by a forge-package within the same ruby process
+setup_path = File.join(ENV['FL_ROOT'],
+                       'vendor/share/bundler/flight-direct-setup.rb')
+require_relative setup_path
 
 # Requires the versioning info
 require 'flight_direct/version'

--- a/lib/flight_direct/cli.rb
+++ b/lib/flight_direct/cli.rb
@@ -30,7 +30,7 @@ module FlightDirect
 
     # Defines the Thor plugin commands using Loki
     glob_libexec('thor/*').each do |path|
-      jit_parse_subcommand(path, clean_bundle: true)
+      jit_parse_subcommand(path)
     end
 
     # Overrides the help command. Only display the help for the root,
@@ -63,7 +63,7 @@ module FlightDirect
       cmd =[
         'bash', flags, path, stringify_args(args), append_help
       ].join(' ')
-      Bundler.with_clean_env { exec(cmd) }
+      exec(cmd)
     end
 
     # The argument array needs to be converted back to a space separated

--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,5 +1,5 @@
 
 module FlightDirect
-  VERSION = '2.1.0'.freeze
-  USER_VERSION = '2018.3'.freeze
+  VERSION = '2.1.1'.freeze
+  USER_VERSION = '2018.4.pre'.freeze
 end


### PR DESCRIPTION
To use the `runtime` version of bundler will `require 'bundler/setup`. Once required, it updates the `Bundler` env vars and prevents the `bundler/setup` from being re-required. Both of these issues makes it tricky to use a separate `Gemfile` within a forge package.

Previously the solution is to start a new ruby process within a clean Bundler environment. This adds greater complexity to simple commands using the `loki` command structure.

Instead `bundle install --standalone` can be used to generate a setup script. This script replaces the `Bundler` runtime dependency and does not alter the environment (except the ruby load path).

This means forge-packages can freely use their own `Gemfile` for there dependencies. This does open up the possibility of version conflicts, between `flight-direct` and the package. The way around this is to keep `flight-direct` dependencies small to minimise the possibility of this happening.