### PR TITLE
Release the `2.1.2` version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2018.3 (2.1.2)] - 2018-10-18
+### Fixed
+- Revert the user facing version to `2018.3`. The user version will no
+  longer be bumped with every release
+
 ## [2018.4.pre (2.1.1)] - 2018-10-17
 ### Fixed
 - Remove the runtime dependency on Bundler. This allows loki forge-packages

--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,5 +1,5 @@
 
 module FlightDirect
-  VERSION = '2.1.1'.freeze
-  USER_VERSION = '2018.4.pre'.freeze
+  VERSION = '2.1.2'.freeze
+  USER_VERSION = '2018.3'.freeze
 end


### PR DESCRIPTION
This release reverts the user version to `2018.3`