### PR TITLE
Release the `2.1.3` version of flight direct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2018.3 (2.1.3)] - 2018-10-23
+### Fixed
+- Update references to `alces` within the help pages to `flight`
+
 ## [2018.3 (2.1.2)] - 2018-10-18
 ### Fixed
 - Revert the user facing version to `2018.3`. The user version will no

--- a/etc/runtime.sh
+++ b/etc/runtime.sh
@@ -20,7 +20,7 @@ fi
 unset flight_conf
 
 # Sets up clusterware
-export cw_BINNAME="alces"
+export cw_BINNAME="flight"
 export cw_CMDDIR="$cw_ROOT/libexec/actions"
 source $cw_ROOT/lib/clusterware.kernel.sh
 if [ -t 2 ]; then

--- a/lib/flight_direct/version.rb
+++ b/lib/flight_direct/version.rb
@@ -1,5 +1,5 @@
 
 module FlightDirect
-  VERSION = '2.1.2'.freeze
+  VERSION = '2.1.3'.freeze
   USER_VERSION = '2018.3'.freeze
 end

--- a/libexec/info/actions/help
+++ b/libexec/info/actions/help
@@ -50,7 +50,7 @@ help_for_action() {
     cat <<EOF
   SYNOPSIS:
 
-    alces about ${action}
+    $cw_BINNAME about ${action}
 
   DESCRIPTION:
 
@@ -63,7 +63,7 @@ help_for_help() {
     cat <<EOF
   SYNOPSIS:
 
-    alces about help [<command>]
+    $cw_BINNAME about help [<command>]
 
   DESCRIPTION:
 


### PR DESCRIPTION
This version rebrands `alces` to `flight`