### PR TITLE
Create a cloud formation template for releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,16 @@ build was successful and can be safely ignored.
 Alternatively installing `rpm-build` will suppress the error, however the
 `rpm` will be built.
 
+### Releasing a new version
+
+New version of `flight-direct` can be released on AWS using the staff
+credentials. All that is required is firing up the release template (below)
+on cloud formation. This will start a build machine and saves the tarball in
+S3 automatically.
+`templates/cloud-release-template.yaml`
+
+NOTE: The release `Version` needs to be given as a parameter to the template.
+
 ### Clean
 
 You can clean up all temporary files generated during the build process with

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ S3 automatically.
 `templates/cloud-release-template.yaml`
 
 NOTE: The release `Version` needs to be given as a parameter to the template.
+The template has been design to work with `cloudware` and use the replace
+syntax (`%Version%`). This allows the template to be used through both
+platforms.
 
 ### Clean
 

--- a/templates/cloud-release-template.yaml
+++ b/templates/cloud-release-template.yaml
@@ -3,7 +3,7 @@ Description: 'Release Flight Direct'
 Parameters:
   Version:
     Type: String
-    Default: 2.1.4
+    Default: %Version%
 Mappings:
   RegionMap:
     eu-west-1:

--- a/templates/cloud-release-template.yaml
+++ b/templates/cloud-release-template.yaml
@@ -1,0 +1,32 @@
+---
+Description: 'Release Flight Direct'
+Parameters:
+  Version:
+    Type: String
+    Default: 2.1.4
+Mappings:
+  RegionMap:
+    eu-west-1:
+      "AMI": "ami-02c26e7b"
+Resources:
+  Machine:
+    Type: AWS::EC2::Instance
+    Properties:
+      AvailabilityZone: !Select
+        - 0
+        - Fn::GetAZs: !Ref 'AWS::Region'
+      ImageId: !FindInMap ["RegionMap", !Ref "AWS::Region", "AMI"]
+      InstanceType: m5d.large
+      IamInstanceProfile: flight-direct-s3
+      Monitoring: true
+      KeyName: aws_ireland
+      UserData:
+        Fn::Base64:
+          Fn::Join:
+            - ''
+            - - "#cloud-config\n"
+              - "runcmd:\n"
+              - "  - curl https://raw.githubusercontent.com/alces-software/flight-direct/master/scripts/release.sh | sudo bash -s "
+              - !Ref Version
+              - "\n"
+              - "  - shutdown now"

--- a/templates/cloud-release-template.yaml
+++ b/templates/cloud-release-template.yaml
@@ -26,7 +26,9 @@ Resources:
             - ''
             - - "#cloud-config\n"
               - "runcmd:\n"
-              - "  - curl https://raw.githubusercontent.com/alces-software/flight-direct/master/scripts/release.sh | sudo bash -s "
+              - "  - curl https://raw.githubusercontent.com/alces-software/flight-direct/"
+              - !Ref Version
+              - "/scripts/release.sh | sudo bash -s "
               - !Ref Version
               - "\n"
               - "  - shutdown now"


### PR DESCRIPTION
Fixes #49 

Previously all releases where done locally, this makes it tricky for
multiple people to preform them.

Instead a cloud formation template has been created. This will create a
machine with write permissions to S3.

It then runs the release bootstrap script